### PR TITLE
feat#3 : seller 회원가입과 로그인 구현.

### DIFF
--- a/omc/src/main/java/com/hotsix/omc/controller/SellerController.java
+++ b/omc/src/main/java/com/hotsix/omc/controller/SellerController.java
@@ -1,12 +1,44 @@
 package com.hotsix.omc.controller;
 
+import com.hotsix.omc.domain.form.customer.CustomerLoginForm;
+import com.hotsix.omc.domain.form.customer.CustomerSignupForm;
+import com.hotsix.omc.domain.form.seller.SellerLoginForm;
+import com.hotsix.omc.domain.form.seller.SellerSignupForm;
+import com.hotsix.omc.domain.form.token.TokenInfo;
+import com.hotsix.omc.service.SellerService;
+import com.hotsix.omc.service.SellerServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @RestController
-@RequestMapping("/store")
+@RequestMapping("/seller")
 @RequiredArgsConstructor
+@Slf4j
 public class SellerController {
+    private final SellerServiceImpl sellerService;
+    @PostMapping("/signup")
+    public ResponseEntity<SellerSignupForm.Response> registerMember(
+            @RequestBody @Valid SellerSignupForm.Request request) {
+        return ResponseEntity.ok(sellerService.register(request));
+    }
+    @PostMapping("/login")
+    public ResponseEntity<TokenInfo> login(
+            @RequestBody @Valid SellerLoginForm form){
+        TokenInfo sellerToken = sellerService.login(form.getEmail(), form.getPassword());
+        return ResponseEntity.ok(sellerToken);
+    }
 
+    @GetMapping("/email-auth")
+    public ResponseEntity<String> emailAuth(HttpServletRequest request){
+        String uuid = request.getParameter("id");
+        log.info("uuid = " + uuid.toString());
+
+        String emailAuthKey = sellerService.emailAuth(uuid);
+        return ResponseEntity.ok(emailAuthKey);
+    }
 }

--- a/omc/src/main/java/com/hotsix/omc/domain/entity/Seller.java
+++ b/omc/src/main/java/com/hotsix/omc/domain/entity/Seller.java
@@ -21,6 +21,7 @@ public class Seller extends BaseEntity {
     private Long id;
     @Column(unique = true)
     private String email;
+    private String name;
     private String password;
     private String phone;
     private String emailAuthKey;

--- a/omc/src/main/java/com/hotsix/omc/domain/form/seller/SellerLoginForm.java
+++ b/omc/src/main/java/com/hotsix/omc/domain/form/seller/SellerLoginForm.java
@@ -1,0 +1,19 @@
+package com.hotsix.omc.domain.form.seller;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SellerLoginForm {
+    @NotBlank
+    @Email
+    private String email;
+    @NotBlank
+    private String password;
+}

--- a/omc/src/main/java/com/hotsix/omc/repository/SellerRepository.java
+++ b/omc/src/main/java/com/hotsix/omc/repository/SellerRepository.java
@@ -1,5 +1,6 @@
 package com.hotsix.omc.repository;
 
+import com.hotsix.omc.domain.entity.Customer;
 import com.hotsix.omc.domain.entity.Seller;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,6 @@ import java.util.Optional;
 public interface SellerRepository extends JpaRepository<Seller, Long> {
 
     Optional<Seller> findByEmail(String email);
+    Optional<Seller> findByEmailAuthKey(String uuid);
 
 }

--- a/omc/src/main/java/com/hotsix/omc/service/CustomerService.java
+++ b/omc/src/main/java/com/hotsix/omc/service/CustomerService.java
@@ -1,14 +1,13 @@
 package com.hotsix.omc.service;
 
 import com.hotsix.omc.components.MailComponents;
+import com.hotsix.omc.config.jwt.JwtTokenProvider;
 import com.hotsix.omc.domain.entity.Customer;
-import com.hotsix.omc.domain.entity.Seller;
 import com.hotsix.omc.domain.form.customer.CustomerDeleteForm;
 import com.hotsix.omc.domain.form.customer.CustomerSignupForm;
 import com.hotsix.omc.domain.form.customer.CustomerSignupForm.Response;
 import com.hotsix.omc.domain.form.token.TokenInfo;
 import com.hotsix.omc.exception.UsersException;
-import com.hotsix.omc.config.jwt.JwtTokenProvider;
 import com.hotsix.omc.repository.CustomerRepository;
 import com.hotsix.omc.repository.SellerRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +35,7 @@ import static com.hotsix.omc.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
-public class CustomerService implements UserDetailsService, PasswordService {
+public class CustomerService implements UserDetailsService {
     private final CustomerRepository customerRepository;
     private final MailComponents mailComponents;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -72,11 +71,6 @@ public class CustomerService implements UserDetailsService, PasswordService {
         return Response.from(request);
     }
 
-    @Override
-    @Transactional
-    public void changePassword(String email, String password) {
-
-    }
 
     public String emailAuth(String uuid) {
         Optional<Customer> optionalCustomer = customerRepository.findByEmailAuthKey(uuid);
@@ -114,7 +108,6 @@ public class CustomerService implements UserDetailsService, PasswordService {
 
     @Override
     public UserDetails loadUserByUsername(String email) {
-        if (customerRepository.findByEmail(email).isPresent()){
         Customer customer = customerRepository.findByEmail(email)
                 .orElseThrow(() ->
                         new UsernameNotFoundException("EMAiL NOT FOUND -> " + email));
@@ -124,19 +117,6 @@ public class CustomerService implements UserDetailsService, PasswordService {
             return new User(customer.getEmail(),
                     customer.getPassword(),
                     customerGrantedAuthorities);
-        }
-
-        else if (sellerRepository.findByEmail(email).isPresent()) {
-            Seller seller = sellerRepository.findByEmail(email)
-                    .orElseThrow(() -> new UsernameNotFoundException("EMAiL NOT FOUND -> " + email));
-
-            List<GrantedAuthority> sellerGrantedAuthorities = new ArrayList<>();
-            sellerGrantedAuthorities.add(new SimpleGrantedAuthority("ROLE_SELLER"));
-            return new User(seller.getEmail(),
-                    seller.getPassword(),
-                    sellerGrantedAuthorities);
-        }
-        return null;
     }
 
     public CustomerDeleteForm delete(Long id) {

--- a/omc/src/main/java/com/hotsix/omc/service/SellerServiceImpl.java
+++ b/omc/src/main/java/com/hotsix/omc/service/SellerServiceImpl.java
@@ -1,30 +1,126 @@
 package com.hotsix.omc.service;
 
 
+import com.hotsix.omc.components.MailComponents;
+import com.hotsix.omc.config.jwt.JwtTokenProvider;
 import com.hotsix.omc.domain.dto.StoreDto;
-import com.hotsix.omc.domain.entity.Address;
-import com.hotsix.omc.domain.entity.Category;
-import com.hotsix.omc.domain.entity.Seller;
-import com.hotsix.omc.domain.entity.Store;
+import com.hotsix.omc.domain.entity.*;
+import com.hotsix.omc.domain.form.customer.CustomerSignupForm;
+import com.hotsix.omc.domain.form.seller.SellerSignupForm;
 import com.hotsix.omc.domain.form.seller.StoreRegisterForm;
 import com.hotsix.omc.domain.form.seller.StoreRegisterForm.Response;
+import com.hotsix.omc.domain.form.token.TokenInfo;
 import com.hotsix.omc.exception.ErrorCode;
 import com.hotsix.omc.exception.UsersException;
 import com.hotsix.omc.repository.SellerRepository;
 import com.hotsix.omc.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.hotsix.omc.domain.entity.CustomerStatus.UNAUTHORIZED;
+import static com.hotsix.omc.exception.ErrorCode.*;
+import static com.hotsix.omc.exception.ErrorCode.PASSWORD_NOT_MATCH;
 
 @Service
 @RequiredArgsConstructor
-public class SellerServiceImpl implements SellerService {
+public class SellerServiceImpl implements SellerService, UserDetailsService {
     private final SellerRepository sellerRepository;
     private final StoreRepository storeRepository;
+    private final MailComponents mailComponents;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider tokenProvider;
 
+
+    public SellerSignupForm.Response register(SellerSignupForm.Request request) {
+        Optional<Seller> optionalSeller = sellerRepository.findByEmail(request.getEmail());
+        if (optionalSeller.isPresent()){
+            throw new UsersException(ALREADY_EXIST_USER);
+        }
+        String encPw = BCrypt.hashpw(request.getPassword(), BCrypt.gensalt());
+        String uuid = UUID.randomUUID().toString();
+
+        Seller seller = Seller.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .password(encPw)
+                .phone(request.getPhone())
+                .emailAuthKey(uuid)
+                .Auth(UNAUTHORIZED)
+                .build();
+        sellerRepository.save(seller);
+
+        String email = request.getEmail();
+        String subject = "Oh! My Car 에 오신 것을 환영합니다!";
+        String text = "<p> OMC 가입을 축하드립니다. </p> <p>아래 링크를 클릭하셔서 가입을 완료해주세요.</p>" +
+                "<div><a target='_blank' href='http://localhost:8080/customer/email-auth?id="
+                + uuid + "'> 가입완료 </a></div>";
+        mailComponents.sendMail(email, subject, text);
+
+        return SellerSignupForm.Response.from(request);
+    }
+
+    public String emailAuth(String uuid) {
+        Optional<Seller> optionalSeller = sellerRepository.findByEmailAuthKey(uuid);
+        if(!optionalSeller.isPresent()){
+            throw new UsersException(BAD_REQUEST);
+        }
+        Seller seller = optionalSeller.get();
+        return seller.getEmailAuthKey();
+    }
+    public TokenInfo login(String email, String password){
+        // id, pw 기반 Authentication 객체생성
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(email, password);
+
+        // 검증 (비밀번호 확인)
+        // authenticate 실행 될 때 loadByUserByUsername 실행
+        validateEmailAndPassword(email, password);
+        Authentication authentication = authenticationManagerBuilder
+                .getObject()
+                .authenticate(authenticationToken);
+
+        return tokenProvider.generateToken(authentication);
+    }
+
+    private void validateEmailAndPassword(String email, String password) {
+        Seller seller = sellerRepository.findByEmail(email)
+                .orElseThrow(() -> new UsersException(EMAIL_NOT_EXIST));
+
+        if (!passwordEncoder.matches(password, seller.getPassword())){
+            throw new UsersException(PASSWORD_NOT_MATCH);
+        }
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        Seller seller = sellerRepository.findByEmail(email)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("EMAiL NOT FOUND -> " + email));
+        List<GrantedAuthority> customerGrantedAuthorities = new ArrayList<>();
+        customerGrantedAuthorities.add(new SimpleGrantedAuthority("ROLE_SELLER"));
+
+        return new User(seller.getEmail(),
+                seller.getPassword(),
+                customerGrantedAuthorities);
+    }
     @Override
     public Response registerStore(StoreRegisterForm.Request request) {
         Seller seller = sellerRepository.findByEmail(request.getEmail())
@@ -95,4 +191,6 @@ public class SellerServiceImpl implements SellerService {
 
         storeRepository.delete(existingStore);
     }
+
+
 }


### PR DESCRIPTION
Changes
---
- 진행하면서 seller 엔터티에 name 이 없어서 추가
- seller controller 에 registerMember, login, emailAuth 추가
- repository 에 findByEmailAuthKey 추가
- domain/form/seller : SellerLoginForm 추가(이메일, 패스워드)