### PR TITLE
feat.028-SELLER-RESERVATION

### DIFF
--- a/omc/src/main/java/com/hotsix/omc/domain/dto/ReservationRequestDto.java
+++ b/omc/src/main/java/com/hotsix/omc/domain/dto/ReservationRequestDto.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @Getter
 @Setter
 @Builder
@@ -11,6 +13,7 @@ public class ReservationRequestDto {
     private Long customerId;
     private Long storeId;
     private String details;
+    private LocalDate serviceDate;
     private String serviceStartHour;
     private String serviceEndHour;
 }

--- a/omc/src/main/java/com/hotsix/omc/domain/dto/ReservationStoreResponseDto.java
+++ b/omc/src/main/java/com/hotsix/omc/domain/dto/ReservationStoreResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -16,5 +17,8 @@ public class ReservationStoreResponseDto {
     private String name;
     private ReservationStatus status;
     private LocalDateTime reservedAt;
+    private LocalDate serviceDate;
+    private String serviceStartHour;
+    private String serviceEndHour;
 }
 

--- a/omc/src/main/java/com/hotsix/omc/domain/entity/Reservation.java
+++ b/omc/src/main/java/com/hotsix/omc/domain/entity/Reservation.java
@@ -4,6 +4,7 @@ package com.hotsix.omc.domain.entity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -26,6 +27,7 @@ public class Reservation {
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
     private String details;
+    private LocalDate serviceDate;
     private String serviceStartHour;
     private String serviceEndHour;
 }

--- a/omc/src/main/java/com/hotsix/omc/repository/ReservationRepository.java
+++ b/omc/src/main/java/com/hotsix/omc/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package com.hotsix.omc.repository;
 import com.hotsix.omc.domain.entity.Customer;
 import com.hotsix.omc.domain.entity.Reservation;
 import com.hotsix.omc.domain.entity.ReservationStatus;
+import com.hotsix.omc.domain.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +19,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             LocalDateTime to,
             ReservationStatus status
     );
+
+    List<Reservation> findReservationByStoreAndReservedAtBetweenAndStatusIn(Store store, LocalDateTime from, LocalDateTime to, ReservationStatus[] status);
 }


### PR DESCRIPTION
Changes
---
-Reservation entity, ReservationRequestDto, ReservationStoreResponseDto 에 private LocalDate serviceDate, private String serviceStartHour, private String serviceEndHour 추가
- Seller의 업체별 예약 확정, 취소, 조회 기능
- 예약 조회 default: 현시점으로부터 1년 전까지, 예약 현황에 관계 없이 조회
 